### PR TITLE
removingFaviconSwaggerUI

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,6 @@ import { env } from './env'
 import { checkInsRoutes } from './http/controllers/check-ins/routes'
 import { gymsRoutes } from './http/controllers/gyms/routes'
 import { usersRoutes } from './http/controllers/users/routes'
-import fs from 'node:fs'
 
 export const app = fastify()
 
@@ -55,39 +54,35 @@ app.register(fastifySwagger, {
   stripBasePath: true,
 })
 
-const buffer = fs.readFileSync('favicon.png')
-const base64Favicon: string = buffer.toString('base64')
+// const buffer = fs.readFileSync('favicon.png', 'base64')
 
-// eslint-disable-next-line
 app.register(fastifySwaggerUi, {
   routePrefix: '/docs',
-
-  theme: {
+  /* theme: {
     favicon: [
       {
         filename: 'favicon.png',
         rel: 'icon',
         sizes: '16x16',
         type: 'image/png',
-        content: base64Favicon,
+        content: Buffer.from(buffer, 'base64'),
       },
     ],
-  },
+  }, */
   uiConfig: {
     deepLinking: true,
     layout: 'BaseLayout',
     showExtensions: true,
     displayRequestDuration: true,
     docExpansion: 'list',
-    showMutatedRequest: true,
     withCredentials: true,
   },
   staticCSP: true,
   transformStaticCSP: (header) => header,
-  transformSpecification: (swaggerObject, request, reply) => {
+  transformSpecification: (swaggerObject, _request, _reply) => {
     return swaggerObject
   },
-  transformSpecificationClone: true,
+  transformSpecificationClone: false,
 })
 
 app.register(usersRoutes)


### PR DESCRIPTION
- SW: Adding swagger documentation for check-ins endpoints
- SW: Removing favicon from swagger ui, because only passing Buffer objects runs well but the library only accept string for it. One issue has already been created on @fastify/swagger-ui official repository (https://github.com/fastify/fastify-swagger-ui/issues/50)
